### PR TITLE
Task1: Add support for INP files without extension (added old Task2 Code corrected in next PR)

### DIFF
--- a/project_explorer/main.py
+++ b/project_explorer/main.py
@@ -268,41 +268,136 @@ class ProjectExplorer(Frame):
 
     def check_selection(self, event: tk.Event):
         """
-        Enable buttons depending on ttk.Treeview selection.
-
-        Currently only the selection of an .inp file triggers enabling of
-        the View and Edit buttons.
-
-        Args:
-            event (tk.Event):
-                The event that triggers the method, usually a button click
-                release event.
+        Enable buttons based on selected file type
+        - .inp/INP files: Enable Edit and View
+        - .his/.HIS files: Enable Plot
+        - Others: Disable all action buttons
         """
         filepath = self.tree.set(event.widget.selection(), "filename")
-        if filepath.endswith(".inp") or os.path.basename(filepath) == "INP":
-            edit_button = self.nametowidget("buttons_frame.edit_button")
-            edit_button.configure(state="enabled")
-            view_button = self.nametowidget("buttons_frame.view_button")
-            view_button.configure(state="enabled")
-            return True
+        full_path = self.tree.set(event.widget.selection(), "filepath")
+        
+        # Get all buttons except New
+        buttons = [btn for btn in self.nametowidget("buttons_frame").winfo_children() 
+                if "new_button" not in str(btn)]
+        
+        # Check file types
+        is_inp = filepath.endswith(".inp") or os.path.basename(filepath) == "INP"
+        is_his = (filepath.endswith(('.his', '.his2', '.his3')) or 
+                os.path.basename(full_path).upper() in ('HIS', 'HIS2', 'HIS3'))
+        
+        # Simple button state control
+        if is_inp:
+            buttons[0].configure(state="enabled")  # Edit
+            buttons[1].configure(state="enabled")  # View
+            buttons[3].configure(state="disabled") # Plot
+        elif is_his:
+            buttons[0].configure(state="disabled") # Edit
+            buttons[1].configure(state="disabled") # View
+            buttons[3].configure(state="enabled")  # Plot
         else:
-            buttons = self.nametowidget("buttons_frame").winfo_children()
-            for button in buttons:
-                if "new_button" not in str(button):
-                    button.configure(state="disabled")
-            return False
+            for btn in buttons:
+                btn.configure(state="disabled")
+        
+        return is_inp or is_his
 
-    def plot_clicked(self, event):
+    def plot_clicked(self, event=None):
         """
-        # TODO: After the plotting functionality is included assign the
-        # TODO: plotting task to this function's calls.
+        Handle the plot button click event by visualizing supported IMSIL output files.
+        
+        Supported file types:
+        - 1D histograms (.his or HIS)
+        - 2D histograms (.his2 or HIS2) 
+        - 3D histograms (.his3 or HIS3)
+        
+        Args:
+            event: The tkinter event object (optional, defaults to None)
+        
+        Behavior:
+        - Checks if selected file is plottable
+        - Calls the appropriate visualization script
+        - Displays errors in message boxes
+        - Maintains platform independence
+        """
+        try:
+            # Get selected item from treeview
+            selected_item = self.tree.selection()
+            if not selected_item:
+                tk.messagebox.showwarning(
+                    "No Selection",
+                    "Please select a file to plot"
+                )
+                return
+                
+            filepath = Path(self.tree.set(selected_item[0], "filepath"))
+            
+            # Validate file type
+            if not self._is_plottable_file(filepath):
+                tk.messagebox.showwarning(
+                    "Unsupported File Type",
+                    f"Cannot plot {filepath.name}.\n"
+                    f"Supported formats: .his/.his2/.his3 or HIS/HIS2/HIS3"
+                )
+                return
+                
+            # Execute plotting script
+            self._execute_plot_script(filepath)
+            
+        except Exception as e:
+            tk.messagebox.showerror(
+                "Plotting Error",
+                f"Failed to plot file:\n{str(e)}"
+            )
 
-        Args: event: The tk.event that called this method.
-
+    def _is_plottable_file(self, path: Path) -> bool:
+        """
+        Check if a file is plottable based on its extension or name.
+        
+        Args:
+            path: Path object to the file
+            
         Returns:
-
+            bool: True if file is plottable, False otherwise
         """
-        pass
+        if not path.is_file():
+            return False
+            
+        ext = path.suffix.lower()
+        name = path.name.upper()
+        
+        return (ext in ('.his', '.his2', '.his3') or 
+                name in ('HIS', 'HIS2', 'HIS3'))
+
+    def _execute_plot_script(self, filepath: Path):
+        """
+        Execute the read_output.py script to visualize the data file.
+        
+        Args:
+            filepath: Path to the data file to plot
+            
+        Raises:
+            subprocess.CalledProcessError: If the script fails
+            Exception: For other unexpected errors
+        """
+        plot_script = Path(__file__).parent.parent / "plot" / "read_output.py"
+        
+        # Platform-independent execution
+        cmd = [sys.executable, str(plot_script), str(filepath)]
+        
+        if platform.system() == "Windows":
+            subprocess.run(
+                cmd,
+                check=True,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+        else:
+            subprocess.run(
+                cmd,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
 
     def view_clicked(self) -> None:
         """

--- a/project_explorer/main.py
+++ b/project_explorer/main.py
@@ -279,7 +279,7 @@ class ProjectExplorer(Frame):
                 release event.
         """
         filepath = self.tree.set(event.widget.selection(), "filename")
-        if filepath.endswith(".inp"):
+        if filepath.endswith(".inp") or os.path.basename(filepath) == "INP":
             edit_button = self.nametowidget("buttons_frame.edit_button")
             edit_button.configure(state="enabled")
             view_button = self.nametowidget("buttons_frame.view_button")
@@ -329,8 +329,11 @@ class ProjectExplorer(Frame):
         """
         filepath = Path(self.tree.set(self.tree.selection()[0],
                                       "filepath"))
-        # Check if selection is valid
-        filepath = filepath if str(filepath).endswith(".inp") else None
+        # Check if selection is valid (either .inp or INP file)
+        filename = os.path.basename(filepath)
+        if not (filename.endswith(".inp") or filename == "INP"):
+            return
+        
         # If started from outside the directory, change cwd to where main.py is
         os.chdir(Path(os.path.abspath(__file__)).parent)
         # Because the parameter editor does not use relative inputs the

--- a/project_explorer/project_browser.py
+++ b/project_explorer/project_browser.py
@@ -35,94 +35,39 @@ ACCEPTED_FILE_EXTENSIONS = (".inp", ".out", ".his", ".cell", ".hisee",
 TEMP_DIR_ID_COUNTER = itertools.count()
 
 
-def populate_tree(tree: ttk.Treeview, node: str, path: PurePath) -> None:
+def populate_tree(tree: ttk.Treeview, node: str, path) -> None:
     """
-    Create one level of tree below node.
-
-    This function is called to populate one level of depth of the tree,
-    and will be subsequently called whenever a new directory is opened.
-
-    Note that the tree.set() method of ttk.TreeView is used for both
-    setting and fetching an item.
-
-    Args:
-        tree:
-            The tree
-        node:
-            Node id
-        path:
-            Path associated with the node.
+    Populate one level of the Treeview below `node`.
+    Show .inp files directly as 'INP' without creating a folder.
     """
-    # Fake project directories have their contents created when their parent
-    # is accessed, therefore no further action is needed
-    if node.startswith("TempDir"):
-        return
     tree.delete(*tree.get_children(node))
 
-    # Search for .inp files inside the passed directory
-    inp_items = [item for item in os.listdir(path) 
-                if str(item).endswith(".inp") or str(item) == "INP"]  # Modified line
-    inp_items.sort()
-    # Create fake directory and assign it the project name for each .inp
-    for inp_item in inp_items:
-        project_name = os.path.splitext(inp_item)[0] if inp_item.endswith(".inp") else inp_item
-        if tree.set(node, "project") != project_name:
-            fake_directory_id = tree.insert(
-                node, "end", "TempDir" + str(next(TEMP_DIR_ID_COUNTER)),
-                text=project_name)
-            tree.set(fake_directory_id, "project", str(project_name))
-            tree.set(fake_directory_id, "filepath", PurePath(path,
-                                                             inp_item))
-    # Iterate through all items and assign them to node
+    path = Path(path)  # sicherstellen, dass es ein echtes Path-Objekt ist
+
     for item in sorted(os.listdir(path)):
-        item_path = PurePath(path, str(item))
-        item_type = "directory" if os.path.isdir(item_path) else "file"
-        # Sort out items that should not be included in the tree
-        if item_type == "directory":
-            # Check for both .inp and INP files in subdirectories
+        item_path = path / item
+        is_dir = item_path.is_dir()
+        is_inp = item_path.suffix.lower() == ".inp" or item_path.name == "INP"
+
+        if is_dir:
+            # Prüfe, ob Unterverzeichnisse .inp Dateien enthalten
             has_inp_files = any(
-                str(f.name).endswith('.inp') or str(f.name) == 'INP' 
-                for f in Path(item_path).rglob('*')
-                if f.is_file()
+                f.is_file() and (f.suffix.lower() == ".inp" or f.name == "INP")
+                for f in item_path.rglob("*")
             )
             if not has_inp_files:
                 continue
-        elif item_type == "file":
-            # Accept both .inp files and INP files
-            if not (str(item).endswith(ACCEPTED_FILE_EXTENSIONS) or str(item) == "INP"):
-                continue
-
-        if item_type == "directory":
             item_id = tree.insert(node, "end", text=item, values=[item])
-            tree.insert(item_id, 0, text=str(item))
             tree.set(item_id, "filepath", item_path)
-        elif item_type == "file":
-            item_id = tree.insert(node, "end", text=item, values=[item])
-            tree.set(item_id, "date", get_date(
-                                              os.stat(item_path).st_mtime))
-            tree.set(item_id, "filepath", item_path)
-            tree.set(item_id, "project", Path(item).stem if item.endswith(".inp") else item)
-            tree.set(item_id, "status", random.choice(
-                ["Completed", "Running"]))  # Add status logic here
-    # Iterate through all created children and move project specific files
-    # to their respective fake project directory
-    projects = [Path(inp_item).stem if inp_item.endswith(".inp") else inp_item 
-               for inp_item in inp_items]  # Modified line
-    for child in tree.get_children(node):
-        child_name = tree.set(child, "filename")
-        project = Path(child_name).stem if child_name.endswith(".inp") else child_name  # Modified line     # project the file belongs to
-        if project in projects:
-            for other_child in tree.get_children(node):
-                if (other_child.startswith("TempDir")
-                        and tree.set(other_child, "project") == project
-                        and other_child != child):
-                    if Path(child_name).suffix == ".inp" or child_name == "INP":  # Modified line
-                        position = 0
-                    elif Path(child_name).suffix == ".out":
-                        position = 1
-                    else:
-                        position = "end"
-                    tree.move(child, other_child, position)
+            tree.insert(item_id, "end", text="")  # Dummy-Knoten
+        elif item_path.is_file():
+            if item_path.suffix.lower() in ACCEPTED_FILE_EXTENSIONS or is_inp:
+                display_name = "INP" if is_inp else item
+                item_id = tree.insert(node, "end", text=display_name, values=[item])
+                tree.set(item_id, "filepath", item_path)
+                tree.set(item_id, "date", get_date(os.stat(item_path).st_mtime))
+                tree.set(item_id, "project", display_name)
+                tree.set(item_id, "status", random.choice(["Completed", "Running"]))
 
 
 def populate_roots(tree: ttk.Treeview, path: PurePath) -> str:


### PR DESCRIPTION
## Changes
- Added support for both `.inp` and `INP` (extensionless) files.
- Updated `populate_tree()`, `check_selection()`, and `edit_clicked()`.
- Fixed `WindowsPath.endswith()` error.

## Related Task
Implements **Task 1** from the project requirements.